### PR TITLE
Create traits for db, redis, api, clean up actual final output of reqs

### DIFF
--- a/src/javascript/reqme/src/requests.js
+++ b/src/javascript/reqme/src/requests.js
@@ -1,4 +1,5 @@
-const API_HOST = "https://leeg-240122.appspot.com"
+//const API_HOST = "https://leeg-240122.appspot.com";
+const API_HOST = "http://localhost:8000";
 
 export function getChampions() {
     return getAsJSON(API_HOST + "/champions")

--- a/src/rust/reqs/src/champions.rs
+++ b/src/rust/reqs/src/champions.rs
@@ -9,8 +9,6 @@ extern crate postgres;
 
 use r2d2::Pool;
 use r2d2_postgres::PostgresConnectionManager;
-use std::fs::File;
-use std::io::Read;
 use std::collections::HashMap;
 use utils::postgres_utils::*;
 use self::postgres::Error;
@@ -126,48 +124,6 @@ impl Champions {
 		self.list.push(champion);
 	}
 
-}
-
-/**
- * Loads a Champions vector from JSON file data
- */
-pub fn load_champions(filename: String) -> Champions {
-	let mut json_file = File::open(filename).expect("Unable to open file");
-	let mut raw_json = String::new();
-	json_file.read_to_string(&mut raw_json).expect("Unable to read file");
-
-	let champs_map : HashMap<i16, String> = serde_json::from_str(&raw_json).unwrap();
-	let mut champions = Champions::new();
-	for (id, name) in champs_map {
-		let role: Vec<String> = Vec::new();
-		champions.push(id, name, role);
-	}
-	champions
-}
-
-pub fn load_champions_with_role(champ_filename: String, role_filename: String) -> Champions {
-	let mut champ_json_file = File::open(champ_filename).expect("Unable to open file");
-	let mut champ_raw_json = String::new();
-	champ_json_file.read_to_string(&mut champ_raw_json).expect("Unable to read file");
-
-	let mut roles_json_file = File::open(role_filename).expect("Unable to open file");
-	let mut roles_raw_json = String::new();
-	roles_json_file.read_to_string(&mut roles_raw_json).expect("Unable to read file");
-
-
-	let champs_map : HashMap<i16, String> = serde_json::from_str(&champ_raw_json).unwrap();
-	let roles_map : HashMap<i16, Vec<String>> = serde_json::from_str(&roles_raw_json).unwrap();
-	let mut champions = Champions::new();
-	for (id, name) in champs_map {
-		champions.push(id, name, roles_map.get(&id).unwrap().clone());
-	}
-	// This is my horrible fix to make the cache work until we do the thing we said we'd do
-	let mut sorted_champions = Champions::new();
-	champions.list.sort_by_key(|key| key.id);
-	for c in champions.list {
-		sorted_champions.push(c.id, c.name, roles_map.get(&c.id).unwrap().clone());
-	}
-	sorted_champions
 }
 
 pub fn load_champions_from_db(pool: Pool<PostgresConnectionManager>) -> Result<Champions, Error> {

--- a/src/rust/reqs/src/lib.rs
+++ b/src/rust/reqs/src/lib.rs
@@ -20,7 +20,7 @@ mod reqs;
 mod summoner;
 
 pub use utils::postgres_utils::get_connection_string;
-pub use champions::{load_champions,load_champions_with_role,Champions, load_champions_from_db};
+pub use champions::{Champions, load_champions_from_db};
 use matches::{load_global_matches_from_db, GlobalMatch, GlobalMatchMatrices};
 use reqs::{GlobalReqService, GlobalServiceWithWeight, combine_req_services};
 use utils::redis_utils::{get_connection, Connection, get_cached_global_reqs, insert_cached_global_reqs, REDIS_DEFAULT_EXPIRE_TIME};
@@ -179,25 +179,6 @@ fn create_then_cache_services(conn: &Connection, derived_matrices: &GlobalMatchM
         
     }
 }
-
-/*
-pub fn get_global_matrix() -> Vec<NamedGlobalService> {
-    let champions = load_champions_with_role(CHAMPIONS_FILE_PATH.to_string(), ROLES_FILE_PATH.to_string());
-    let redis_connection = get_connection();
-    let mut service_vector: Vec<NamedGlobalService> = Vec::with_capacity(champions.get_list().len());
-    for index in 0..champions.get_list().len() {
-        let champ_name = &champions.get_list()[index].name;
-        let empty_vec: Vec<String> = Vec::new();
-        let mut single_champ_vec: Vec<String> = Vec::new();
-        single_champ_vec.push(champ_name.clone());
-        let r = get_or_create_global_req_service(&redis_connection, &empty_vec, &single_champ_vec, &champions, false);
-        service_vector.push(NamedGlobalService {
-            req_service: r.req_service,
-            champ_name:  champ_name.clone()
-        });
-    }
-    service_vector
-}*/
 
 pub fn get_summoner_mastery_by_name(name: String, pool: Pool<PostgresConnectionManager>) -> Result<Summoner, Box<Error>> {
     let region = Region::NA;

--- a/src/rust/reqs/src/lib.rs
+++ b/src/rust/reqs/src/lib.rs
@@ -19,7 +19,7 @@ mod summoner;
 
 pub use utils::postgres_utils::{get_connection_string, FromDatabase};
 pub use champions::{Champions, load_champions_from_db};
-use matches::{load_global_matches_from_db, GlobalMatch, GlobalMatchContainer, GlobalMatchMatrices};
+use matches::{GlobalMatch, GlobalMatchContainer, GlobalMatchMatrices};
 use reqs::{GlobalReqService, GlobalServiceWithWeight, combine_req_services};
 use utils::redis_utils::{get_connection, RedisConnection, Cacheable};
 use itertools::Itertools;

--- a/src/rust/reqs/src/matches.rs
+++ b/src/rust/reqs/src/matches.rs
@@ -10,9 +10,6 @@ extern crate postgres;
 use champions::Champions;
 use utils::postgres_utils::*;
 
-use r2d2::Pool;
-use r2d2_postgres::PostgresConnectionManager;
-
 use self::postgres::Error;
 
 #[derive(Debug, Clone)]
@@ -51,7 +48,7 @@ impl GlobalMatch {
  * games' scores and return.
  */
 pub fn load_global_matches_from_db(same_team: &Vec<String>, opp_team: &Vec<String>, 
-                                   champions: &Champions, pool: Pool<PostgresConnectionManager>) 
+                                   champions: &Champions, pool: ConnectionPool) 
                                    -> Result<Vec<GlobalMatch>, Error> {
     println!("{:?}, {:?}", same_team, opp_team);
     if same_team.is_empty() && opp_team.is_empty() {
@@ -105,7 +102,7 @@ pub fn load_global_matches_from_db(same_team: &Vec<String>, opp_team: &Vec<Strin
 *   empty arrays, not sure if postgres optimizes it away. Also requires just 1 query
 *   that we can just duplicate for same and opp.
 */
-fn load_all_matches(champions: &Champions, pool: Pool<PostgresConnectionManager>) -> Result<Vec<GlobalMatch>, Error> {
+fn load_all_matches(champions: &Champions, pool: ConnectionPool) -> Result<Vec<GlobalMatch>, Error> {
     let conn = pool.get().unwrap();
     let mut matches: Vec<GlobalMatch> = Vec::new();
     for row in &conn.query(Q_ALL_MATCHES, &[])? {

--- a/src/rust/reqs/src/matches.rs
+++ b/src/rust/reqs/src/matches.rs
@@ -131,6 +131,36 @@ fn load_all_matches(champions: &Champions, pool: ConnectionPool) -> Result<Vec<G
     Ok(matches)
 }
 
+pub struct GlobalMatchContainer<'a> {
+    pub matches: Vec<GlobalMatch>,
+    pub champions: &'a Champions,
+    pub same_team: &'a Vec<String>,
+    pub opp_team: &'a Vec<String>
+}
+
+impl<'a> GlobalMatchContainer<'a> {
+    pub fn with_teams_and_champs(same_team: &'a Vec<String>, opp_team: &'a Vec<String>, 
+                                   champions: &'a Champions) -> GlobalMatchContainer<'a> {
+        GlobalMatchContainer {
+            matches: Vec::new(),
+            champions: champions,
+            same_team: same_team,
+            opp_team: opp_team
+        }
+    }
+}
+
+impl<'a> FromDatabase for GlobalMatchContainer<'a> {
+    type Data = GlobalMatchContainer<'a>; 
+
+    fn from_database(self, pool: ConnectionPool) -> Result<Self::Data, Error> {
+       let matches = load_global_matches_from_db(self.same_team, self.opp_team, self.champions, pool)?;
+       let mut container = GlobalMatchContainer::with_teams_and_champs(self.same_team, self.opp_team, self.champions);
+       container.matches = matches;
+       Ok(container)
+    }
+}
+
 pub struct GlobalMatchMatrices {
     pub same_derived_matrix: Vec<Vec<GlobalMatch>>,
     pub opp_derived_matrix: Vec<Vec<GlobalMatch>>

--- a/src/rust/reqs/src/reqs.rs
+++ b/src/rust/reqs/src/reqs.rs
@@ -5,7 +5,7 @@
  */
 
 use champions::Champions;
-use matches::{GlobalMatch};
+use matches::{GlobalMatch, GlobalMatchContainer};
 use scores::{Score, ScoreVector, GlobalScoreVectors};
 use champions::Champion;
 use utils::argmax::argmax_idx;
@@ -43,6 +43,10 @@ impl GlobalReqService {
 			opp_picks: opp_picks.clone(),
 			score_vectors: GlobalScoreVectors::from_global_matches(matches, num_champions),
 		};
+	}
+
+	pub fn from_matches_container(match_container: &GlobalMatchContainer) -> GlobalReqService {
+		Self::from_matches(&match_container.matches, match_container.same_team, match_container.opp_team, match_container.champions.len())
 	}
 
 	/**

--- a/src/rust/reqs/src/reqs.rs
+++ b/src/rust/reqs/src/reqs.rs
@@ -6,8 +6,8 @@
 
 use champions::Champions;
 use matches::{GlobalMatch};
-use scores::{ScoreVector, GlobalScoreVectors};
-
+use scores::{Score, ScoreVector, GlobalScoreVectors};
+use champions::Champion;
 use utils::argmax::argmax_idx;
 
 // Used for comparisons. The "empty product" is 1 instead of 0, but 1 is greater than any
@@ -151,4 +151,10 @@ pub fn combine_req_services(services: &Vec<GlobalServiceWithWeight>, team_picks:
 		}
 	}
 	combined_service
+}
+
+struct Req {
+	champion: Champion,
+	score: Score,
+	message: Option<String>
 }

--- a/src/rust/reqs/src/scores.rs
+++ b/src/rust/reqs/src/scores.rs
@@ -11,7 +11,7 @@ use matches::GlobalMatch;
  * The "meaning" of a Score is determined by the structure using it,
  * but a higher score is generally better than a lower one.
  */
-type Score = f64;
+pub type Score = f64;
 
 pub struct GlobalMatchCounts {
     same_wins: Vec<u32>,

--- a/src/rust/reqs/src/summoner.rs
+++ b/src/rust/reqs/src/summoner.rs
@@ -1,5 +1,5 @@
 use utils::postgres_utils::*;
-use utils::redis_utils::{RedisConnection, get_cached_summoner_id, get_cached_summoner_masteries, insert_cached_summoner_id, insert_cached_summoner_masteries};
+use utils::redis_utils::{Cacheable, RedisConnection, get_cached_summoner_id, insert_cached_summoner_id};
 use utils::riot_api_utils::*;
 use utils::summoner_utils::*;
 use std::error::Error;

--- a/src/rust/reqs/src/utils/postgres_utils.rs
+++ b/src/rust/reqs/src/utils/postgres_utils.rs
@@ -58,11 +58,11 @@ pub fn get_connection_string() -> String {
     connection_string
 }
 
-pub trait FromPostgres {
+pub trait FromDatabase {
     type Data; 
-    fn from_database(&self, pool: ConnectionPool) -> Result<Self::Data, self::postgres::Error>;
+    fn from_database(self, pool: ConnectionPool) -> Result<Self::Data, Error>;
 }
 
-pub trait ToPostgres {
-    fn insert_into_database(&self, pool: ConnectionPool) -> Result<(), self::postgres::Error>;
+pub trait ToDatabase {
+    fn insert_into_database(&self, pool: ConnectionPool) -> Result<(), Error>;
 }

--- a/src/rust/reqs/src/utils/postgres_utils.rs
+++ b/src/rust/reqs/src/utils/postgres_utils.rs
@@ -58,7 +58,11 @@ pub fn get_connection_string() -> String {
     connection_string
 }
 
-trait FromPostgres {
+pub trait FromPostgres {
     type Data; 
     fn from_database(&self, pool: ConnectionPool) -> Result<Self::Data, self::postgres::Error>;
+}
+
+pub trait ToPostgres {
+    fn insert_into_database(&self, pool: ConnectionPool) -> Result<(), self::postgres::Error>;
 }

--- a/src/rust/reqs/src/utils/postgres_utils.rs
+++ b/src/rust/reqs/src/utils/postgres_utils.rs
@@ -8,6 +8,9 @@ use std::env;
 
 pub use self::postgres::{Connection, Error, TlsMode};
 
+
+pub type ConnectionPool = r2d2::Pool<r2d2_postgres::PostgresConnectionManager>;
+
 const DB_CONFIG_PATH: &str = "Db_config.toml";
 // TODO: it would be pretty cool to have a macro that takes care of this stuff depending on arrays
 // you pass in or something
@@ -53,4 +56,9 @@ pub fn get_connection_string() -> String {
 
     let connection_string = format!("postgres://{}:{}@{}/{}", config.user, config.password, host, config.database);
     connection_string
+}
+
+trait FromPostgres {
+    type Data; 
+    fn from_database(&self, pool: ConnectionPool) -> Result<Self::Data, self::postgres::Error>;
 }

--- a/src/rust/reqs/src/utils/postgres_utils.rs
+++ b/src/rust/reqs/src/utils/postgres_utils.rs
@@ -6,7 +6,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::env;
 
-pub use self::postgres::{Connection, Error, TlsMode};
+pub use self::postgres::{Error, TlsMode};
 
 
 pub type ConnectionPool = r2d2::Pool<r2d2_postgres::PostgresConnectionManager>;

--- a/src/rust/reqs/src/utils/redis_utils.rs
+++ b/src/rust/reqs/src/utils/redis_utils.rs
@@ -49,10 +49,6 @@ fn keyname_from_name_and_region(name: &String, region: &Region) -> String {
     format!("summonerid+{}-{}", name, region.to_string())
 }
 
-fn keyname_from_id_masteries(id: &String) -> String {
-    format!("masteries+{}", id)
-}
-
 /**
 * Get cached GlobalServiceWithWeight from Redis if one exists.
 */
@@ -97,30 +93,6 @@ pub fn insert_cached_summoner_id(conn: &Connection, name: &String,
     let key = keyname_from_name_and_region(name, region);
     println!("inserting id for {}", key);
     insert_key_value_to_cache(&conn, key, id.clone(), Some(REDIS_DEFAULT_EXPIRE_TIME_SUMMONER_ID))
-}
-
-/**
-*   Gets cached summoner masteries by id, if one exists.
-*/
-pub fn get_cached_summoner_masteries(conn: &Connection, id: &String) -> Result<Masteries, RedisError> {
-    let key = keyname_from_id_masteries(id);
-    println!("getting masteries for {}", key);
-    match get_key_from_cache(&conn, &key) {
-        Ok(res) => Ok(serde_json::from_str(&(res)).unwrap()),
-        Err(e) => Err(e)
-    }
-}
-
-
-/**
-*   Inserts summoner masteries to redis - default expire time 1 day.
-*/
-pub fn insert_cached_summoner_masteries(conn: &Connection, id: &String, 
-                                        masteries: Masteries) -> Result<Vec<String>, RedisError> {
-    let key = keyname_from_id_masteries(id);
-    println!("inserting masteries for {}", key);
-    let val = json!(masteries).to_string();
-    insert_key_value_to_cache(&conn, key, val, Some(REDIS_DEFAULT_EXPIRE_TIME_SUMMONER_ID))
 }
 
 /**

--- a/src/rust/reqs/src/utils/redis_utils.rs
+++ b/src/rust/reqs/src/utils/redis_utils.rs
@@ -1,13 +1,9 @@
 pub extern crate redis;
-extern crate serde_json;
 extern crate serde;
 
-use self::redis::{Client, Connection, Commands};
 pub use self::redis::RedisError;
-use reqs::GlobalServiceWithWeight;
+use self::redis::Connection;
 use self::serde::{Serialize, Deserialize};
-use self::serde_json::json;
-use super::summoner_utils::{Region, Masteries};
 use std::env;
 
 pub const REDIS_DEFAULT_EXPIRE_TIME: usize = 3600;
@@ -30,57 +26,6 @@ pub fn get_connection() -> Result<Connection, RedisError> {
     debug!("client str for redis: {}", client_str);
     let client = redis::Client::open(client_str)?;    
     client.get_connection()
-}
-
-/**
-*    E.g. sleepo mode - NA -> summonerid+sleepo mode-NA
-*/
-fn keyname_from_name_and_region(name: &String, region: &Region) -> String {
-    format!("summonerid+{}-{}", name, region.to_string())
-}
-
-
-/**
-*   Gets cached summoner id from name and region, if one exists.
-*/
-pub fn get_cached_summoner_id(conn: &Connection, name: &String, region: &Region) 
-                              -> Result<String, RedisError> {
-    let key = keyname_from_name_and_region(name, region);
-    println!("getting id for {}", key);
-    get_key_from_cache(&conn, &key)
-}
-
-/**
-*   Inserts summoner id to redis - default expire time 1 day.
-*/
-pub fn insert_cached_summoner_id(conn: &Connection, name: &String, 
-                                 region: &Region, id: &String) 
-                                 -> Result<Vec<String>, RedisError> {
-    let key = keyname_from_name_and_region(name, region);
-    println!("inserting id for {}", key);
-    insert_key_value_to_cache(&conn, key, id.clone(), Some(REDIS_DEFAULT_EXPIRE_TIME_SUMMONER_ID))
-}
-
-/**
-* Yep.
-*/
-pub fn get_key_from_cache(conn: &Connection, key: &String) -> Result<String, RedisError> {
-    conn.get(key)
-}
-
-/**
-* If an expiry time in seconds is specified, set the key to expire then. Otherwise, set without expiry.
-*/
-pub fn insert_key_value_to_cache(conn: &Connection, key: String, val: String, expire_time: Option<usize>) 
-                                -> Result<Vec<String>, RedisError> {
-     match expire_time {
-        Some(time) => {
-            conn.set_ex(key, val, time)
-        },
-        None => {
-            conn.set(key, val)
-        }
-    }
 }
 
 pub trait Cacheable<'de> {

--- a/src/rust/reqs/src/utils/riot_api_utils.rs
+++ b/src/rust/reqs/src/utils/riot_api_utils.rs
@@ -26,7 +26,7 @@ pub trait FromRiotApi {
 impl FromRiotApi for SummonerId {
     type DeserializedResponse = SummonerId;
 
-    fn from_riot_api(identifier: &str) -> Result<SummonerId, Box<Error>> {
+    fn from_riot_api(identifier: &str) -> Result<Self::DeserializedResponse, Box<Error>> {
         let riot_api_key = env::var(RIOT_API_KEY_ENV_VAR)?;
         let query_url = format!("{}{}{}{}{}", RIOT_API_URL_ROOT, 
                                  RIOT_API_SUMMONER_PATH, identifier, 
@@ -40,7 +40,7 @@ impl FromRiotApi for SummonerId {
 impl FromRiotApi for Masteries {
     type DeserializedResponse = Masteries;
 
-    fn from_riot_api(identifier: &str) -> Result<Masteries, Box<Error>> {
+    fn from_riot_api(identifier: &str) -> Result<Self::DeserializedResponse , Box<Error>> {
         let riot_api_key = env::var(RIOT_API_KEY_ENV_VAR)?;
         let query_url = format!("{}{}{}{}{}", RIOT_API_URL_ROOT, 
                                  RIOT_API_MASTERIES_PATH, identifier, 

--- a/src/rust/reqs/src/utils/summoner_utils.rs
+++ b/src/rust/reqs/src/utils/summoner_utils.rs
@@ -1,7 +1,7 @@
 extern crate serde_json;
 
-use super::postgres_utils::*;
-use super::redis_utils::{RedisConnection, Cacheable, RedisError, REDIS_DEFAULT_EXPIRE_TIME_SUMMONER_ID};
+use utils::postgres_utils::*;
+use utils::redis_utils::{RedisConnection, Cacheable, RedisError, REDIS_DEFAULT_EXPIRE_TIME, REDIS_DEFAULT_EXPIRE_TIME_SUMMONER_ID};
 use self::serde_json::json;
 use utils::redis_utils::redis::Commands;
 use std::collections::HashMap;
@@ -111,6 +111,6 @@ impl Cacheable<'_> for Masteries {
          debug!("inserting masteries for {}", self.id);
        
         let key = self.get_cache_key_name();
-        conn.set_ex(key, json!(self).to_string(), REDIS_DEFAULT_EXPIRE_TIME_SUMMONER_ID)
+        conn.set_ex(key, json!(self).to_string(), REDIS_DEFAULT_EXPIRE_TIME)
     }
 }

--- a/src/rust/reqs/src/utils/summoner_utils.rs
+++ b/src/rust/reqs/src/utils/summoner_utils.rs
@@ -1,4 +1,4 @@
-use postgres_utils::*;
+use super::postgres_utils::*;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -41,22 +41,48 @@ pub struct Masteries {
 
 impl Masteries {
 
-    pub fn from_mastery_vec(id: &String, response: Vec<Mastery>) -> Masteries {
-        let mut masteries = Masteries {
+    pub fn populate_from_mastery_vec(mut self, response: Vec<Mastery>) -> Masteries {
+        for mastery in response {
+            self.map.insert(mastery.champion_id, mastery);
+        }
+        self
+    }
+
+    pub fn with_id(id: &String) -> Masteries {
+        Masteries {
             id: id.clone(),
             map: HashMap::new()
-        };
-        for mastery in response {
-            masteries.map.insert(mastery.champion_id, mastery);
         }
-        masteries
     }
 
 }
 
-impl FromPostgres for Masteries {
+impl FromDatabase for Masteries {
     type Data = Masteries; 
-    fn from_database(&self, pool: ConnectionPool) -> Result<Self::Data, self::postgres::Error> {
-        unimplemented!();
-    };
+
+    fn from_database(self, pool: ConnectionPool) -> Result<Masteries, Error> {
+        let conn = pool.get().unwrap();
+        let mut mastery_vec: Vec<Mastery> = Vec::new();
+        for row in &conn.query(Q_SUMMONER_MASTERIES, &[&self.id])? {
+            mastery_vec.push(Mastery {
+                champion_id: row.get(0),
+                mastery_level: row.get(1),
+                mastery_points: row.get(2)
+            });
+        }
+        Ok(self.populate_from_mastery_vec(mastery_vec))
+    }
+}
+
+impl ToDatabase for Masteries {
+    fn insert_into_database(&self, pool: ConnectionPool) -> Result<(), Error> {
+        let conn = pool.get().unwrap();
+        let transaction = conn.transaction()?;
+        let stmt = transaction.prepare(INSERT_SUMMONER_MASTERIES)?;
+        for (_, mastery) in self.map.clone().into_iter() {
+            stmt.execute(&[&self.id, &mastery.champion_id, &mastery.mastery_level, &mastery.mastery_points])?;
+        }
+        transaction.commit()?;
+        Ok(())
+    }
 }

--- a/src/rust/reqs/src/utils/summoner_utils.rs
+++ b/src/rust/reqs/src/utils/summoner_utils.rs
@@ -1,3 +1,4 @@
+use postgres_utils::*;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -51,4 +52,11 @@ impl Masteries {
         masteries
     }
 
+}
+
+impl FromPostgres for Masteries {
+    type Data = Masteries; 
+    fn from_database(&self, pool: ConnectionPool) -> Result<Self::Data, self::postgres::Error> {
+        unimplemented!();
+    };
 }

--- a/src/rust/reqs/src/utils/summoner_utils.rs
+++ b/src/rust/reqs/src/utils/summoner_utils.rs
@@ -1,7 +1,7 @@
 extern crate serde_json;
 
 use utils::postgres_utils::*;
-use utils::redis_utils::{RedisConnection, Cacheable, RedisError, REDIS_DEFAULT_EXPIRE_TIME, REDIS_DEFAULT_EXPIRE_TIME_SUMMONER_ID};
+use utils::redis_utils::{RedisConnection, Cacheable, RedisError, REDIS_DEFAULT_EXPIRE_TIME};
 use self::serde_json::json;
 use utils::redis_utils::redis::Commands;
 use std::collections::HashMap;


### PR DESCRIPTION
This PR starts a big cleanup of the reqs lib. Create traits Cacheable, FromDatabase, ToDatabase, and FromRiotApi and impl for the necessary structs to replace all of the individual functions. Also cleaned up a bunch of compiler warnings and some other general nice stuff. 